### PR TITLE
feat: add the EraVM assembler and linker API

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile = "default"
-channel = "1.79.0"
+channel = "1.80.1"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+profile = "default"
+channel = "1.79.0"

--- a/src/linker.rs
+++ b/src/linker.rs
@@ -13,12 +13,25 @@ pub enum LLVMLinkerMode {
 }
 
 extern "C" {
-    /// Call the assembler library with `InMemBuf` containing assembly.
+    /// Translate textual assembly to object code.
     /// 
-    /// The unlinked bytecode is written to `OutMemBuf`, which must then be
-    /// passed to `LLVMLinkEraVM`.
+    /// The unlinked EraVM bytecode is written to `OutMemBuf`, which must then be
+    /// passed to `LLVMLinkEraVM` for linkage.
     pub fn LLVMAssembleEraVM(
         TargetMachine: LLVMTargetMachineRef,
+        InMemBuf: LLVMMemoryBufferRef,
+        OutMemBuf: *mut LLVMMemoryBufferRef,
+    ) -> LLVMBool;
+
+    /// Check if the bytecode fits into the EraVM size limit.
+    pub fn LLVMExceedsSizeLimitEraVM(
+        InMemBuf: LLVMMemoryBufferRef,
+    ) -> LLVMBool;
+    
+    /// Link EraVM module.
+    ///
+    /// Removes the ELF wrapper from an EraVM module.
+    pub fn LLVMLinkEraVM(
         InMemBuf: LLVMMemoryBufferRef,
         OutMemBuf: *mut LLVMMemoryBufferRef,
     ) -> LLVMBool;
@@ -28,12 +41,4 @@ extern "C" {
     /// Destroys the source module, returns true on error. Use the diagnostic
     /// handler to get any diagnostic message.
     pub fn LLVMLinkModules2(Dest: LLVMModuleRef, Src: LLVMModuleRef) -> LLVMBool;
-    
-    /// Link EraVM module.
-    ///
-    /// Removes the ELF wrapper from an EraVM module.
-    pub fn LLVMLinkEraVM(
-        InMemBuf: LLVMMemoryBufferRef,
-        OutMemBuf: *mut LLVMMemoryBufferRef,
-    ) -> LLVMBool;
 }

--- a/src/linker.rs
+++ b/src/linker.rs
@@ -1,5 +1,7 @@
 //! The module/file/archive linker
 
+use crate::target_machine::LLVMTargetMachineRef;
+
 use super::prelude::*;
 
 #[repr(C)]
@@ -11,6 +13,16 @@ pub enum LLVMLinkerMode {
 }
 
 extern "C" {
+    /// Call the assembler library with `InMemBuf` containing assembly.
+    /// 
+    /// The unlinked bytecode is written to `OutMemBuf`, which must then be
+    /// passed to `LLVMLinkEraVM`.
+    pub fn LLVMAssembleEraVM(
+        TargetMachine: LLVMTargetMachineRef,
+        InMemBuf: LLVMMemoryBufferRef,
+        OutMemBuf: *mut LLVMMemoryBufferRef,
+    ) -> LLVMBool;
+    
     /// Link the source module into the destination module.
     ///
     /// Destroys the source module, returns true on error. Use the diagnostic

--- a/src/linker.rs
+++ b/src/linker.rs
@@ -21,11 +21,13 @@ extern "C" {
         TargetMachine: LLVMTargetMachineRef,
         InMemBuf: LLVMMemoryBufferRef,
         OutMemBuf: *mut LLVMMemoryBufferRef,
+        ErrorMessage: *mut *mut ::libc::c_char,
     ) -> LLVMBool;
 
     /// Check if the bytecode fits into the EraVM size limit.
     pub fn LLVMExceedsSizeLimitEraVM(
         InMemBuf: LLVMMemoryBufferRef,
+        MetadataSize: ::libc::c_uint,
     ) -> LLVMBool;
     
     /// Link EraVM module.
@@ -34,6 +36,9 @@ extern "C" {
     pub fn LLVMLinkEraVM(
         InMemBuf: LLVMMemoryBufferRef,
         OutMemBuf: *mut LLVMMemoryBufferRef,
+        MetadataPtr: *const ::libc::c_char,
+        MetadataSize: ::libc::c_uint,
+        ErrorMessage: *mut *mut ::libc::c_char,
     ) -> LLVMBool;
     
     /// Link the source module into the destination module.

--- a/src/linker.rs
+++ b/src/linker.rs
@@ -16,4 +16,12 @@ extern "C" {
     /// Destroys the source module, returns true on error. Use the diagnostic
     /// handler to get any diagnostic message.
     pub fn LLVMLinkModules2(Dest: LLVMModuleRef, Src: LLVMModuleRef) -> LLVMBool;
+    
+    /// Link EraVM module.
+    ///
+    /// Removes the ELF wrapper from an EraVM module.
+    pub fn LLVMLinkEraVM(
+        InMemBuf: LLVMMemoryBufferRef,
+        OutMemBuf: *mut LLVMMemoryBufferRef,
+    ) -> LLVMBool;
 }


### PR DESCRIPTION
# What ❔

Adds the EraVM linking function.

## Why ❔

Is it needed to complete the pipeline with the new LLVM-based assembler and linker.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
