### PR TITLE
fix: linker API integer types

### DIFF
--- a/src/linker.rs
+++ b/src/linker.rs
@@ -51,8 +51,8 @@ extern "C" {
     pub fn LLVMDisassembleEraVM(
         TargetMachine: LLVMTargetMachineRef,
         InMemBuf: LLVMMemoryBufferRef,
-        PC: u32,
-        Options: u32,
+        PC: u64,
+        Options: u64,
         OutMemBuf: *mut LLVMMemoryBufferRef,
         ErrorMessage: *mut *mut ::libc::c_char,
     ) -> LLVMBool;

--- a/src/linker.rs
+++ b/src/linker.rs
@@ -19,17 +19,6 @@ extern "C" {
     /// handler to get any diagnostic message.
     pub fn LLVMLinkModules2(Dest: LLVMModuleRef, Src: LLVMModuleRef) -> LLVMBool;
 
-    /// Link EVM modules.
-    ///
-    /// Is supposed to link both EVM deploy and runtime code, and CREATE dependencies.
-    pub fn LLVMLinkMemoryBuffers(
-        InMemBufs: *const LLVMMemoryBufferRef,
-        NumInBufs: u64,
-        OutMemBuf: *mut LLVMMemoryBufferRef,
-        LldArgs: *const *const ::libc::c_char,
-        NumLldArgs: u64,
-    ) -> LLVMBool;
-
     /// Translate textual assembly to object code.
     ///
     /// The unlinked EraVM bytecode is written to `OutMemBuf`, which must then be

--- a/src/linker.rs
+++ b/src/linker.rs
@@ -19,6 +19,17 @@ extern "C" {
     /// handler to get any diagnostic message.
     pub fn LLVMLinkModules2(Dest: LLVMModuleRef, Src: LLVMModuleRef) -> LLVMBool;
 
+    /// Link EVM modules.
+    ///
+    /// Is supposed to link both EVM deploy and runtime code, and CREATE dependencies.
+    pub fn LLVMLinkMemoryBuffers(
+        InMemBufs: *const LLVMMemoryBufferRef,
+        NumInBufs: u64,
+        OutMemBuf: *mut LLVMMemoryBufferRef,
+        LldArgs: *const *const ::libc::c_char,
+        NumLldArgs: u64,
+    ) -> LLVMBool;
+
     /// Translate textual assembly to object code.
     ///
     /// The unlinked EraVM bytecode is written to `OutMemBuf`, which must then be
@@ -40,8 +51,8 @@ extern "C" {
     pub fn LLVMDisassembleEraVM(
         TargetMachine: LLVMTargetMachineRef,
         InMemBuf: LLVMMemoryBufferRef,
-        PC: ::libc::c_uint,
-        Options: ::libc::c_uint,
+        PC: u32,
+        Options: u32,
         OutMemBuf: *mut LLVMMemoryBufferRef,
         ErrorMessage: *mut *mut ::libc::c_char,
     ) -> LLVMBool;
@@ -53,21 +64,18 @@ extern "C" {
     pub fn LLVMAddMetadataEraVM(
         InMemBuf: LLVMMemoryBufferRef,
         MetadataPtr: *const ::libc::c_char,
-        MetadataSize: ::libc::c_uint,
+        MetadataSize: u64,
         OutMemBuf: *mut LLVMMemoryBufferRef,
         ErrorMessage: *mut *mut ::libc::c_char,
     ) -> LLVMBool;
 
     /// Check if the bytecode fits into the EraVM size limit.
-    pub fn LLVMExceedsSizeLimitEraVM(
-        InMemBuf: LLVMMemoryBufferRef,
-        MetadataSize: ::libc::c_uint,
-    ) -> LLVMBool;
+    pub fn LLVMExceedsSizeLimitEraVM(InMemBuf: LLVMMemoryBufferRef, MetadataSize: u64) -> LLVMBool;
 
     /// Return unresolved symbols from the ELF wrapper.
     pub fn LLVMGetUndefinedLinkerSymbolsEraVM(
         InMemBuf: LLVMMemoryBufferRef,
-        LinkerSymbolsSize: *mut ::libc::c_uint,
+        LinkerSymbolsSize: *mut u64,
     ) -> *const *const ::libc::c_char;
 
     /// Link EraVM module.
@@ -78,7 +86,7 @@ extern "C" {
         OutMemBuf: *mut LLVMMemoryBufferRef,
         LinkerSymbols: *const *const ::libc::c_char,
         LinkerSymbolValues: *const ::libc::c_char,
-        LinkerSymbolsSize: ::libc::c_uint,
+        LinkerSymbolsSize: u64,
         ErrorMessage: *mut *mut ::libc::c_char,
     ) -> LLVMBool;
 }


### PR DESCRIPTION
# What ❔

Fixes some API types by making them 64 bits.

## Why ❔

Most of them turned out to be incorrect.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
