### PR TITLE
fix: memory leak with undefined symbols

### DIFF
--- a/src/linker.rs
+++ b/src/linker.rs
@@ -96,6 +96,12 @@ extern "C" {
         LinkerSymbolsSize: *mut u64,
     ) -> *const *const ::libc::c_char;
 
+    /// Dispose the unresolved symbols.
+    pub fn LLVMDisposeUndefinedLinkerSymbolsEraVM(
+        LinkerSymbols: *const *const ::libc::c_char,
+        LinkerSymbolsSize: u64,
+    );
+
     /// Link EraVM module.
     ///
     /// Removes the ELF wrapper from an EraVM module if all symbols are resolved.


### PR DESCRIPTION
# What ❔

Fixes a memory leak with undefined symbols.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
