### PR TITLE
feat(eravm): linkage of factory dependencies

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,3 +17,4 @@
 - [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
 - [ ] Tests for the changes have been added / updated.
 - [ ] Documentation comments have been added / updated.
+- [ ] Code has been formatted via `cargo fmt`.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@
 <!-- Check your PR fulfills the following items. -->
 <!-- For draft PRs check the boxes as you complete them. -->
 
-- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
+- [ ] PR title corresponds to the body of PR.
 - [ ] Tests for the changes have been added / updated.
 - [ ] Documentation comments have been added / updated.
 - [ ] Code has been formatted via `cargo fmt`.

--- a/src/linker.rs
+++ b/src/linker.rs
@@ -90,16 +90,19 @@ extern "C" {
     /// Check if the bytecode fits into the EraVM size limit.
     pub fn LLVMExceedsSizeLimitEraVM(InMemBuf: LLVMMemoryBufferRef, MetadataSize: u64) -> LLVMBool;
 
-    /// Return unresolved symbols from the ELF wrapper.
-    pub fn LLVMGetUndefinedLinkerSymbolsEraVM(
+    /// Return undefined references of the ELF object.
+    pub fn LLVMGetUndefinedReferencesEraVM(
         InMemBuf: LLVMMemoryBufferRef,
+        LinkerSymbols: *mut *mut *mut ::libc::c_char,
         LinkerSymbolsSize: *mut u64,
-    ) -> *const *const ::libc::c_char;
+        FactoryDependencies: *mut *mut *mut ::libc::c_char,
+        FactoryDependenciesSize: *mut u64,
+    );
 
-    /// Dispose the unresolved symbols.
-    pub fn LLVMDisposeUndefinedLinkerSymbolsEraVM(
-        LinkerSymbols: *const *const ::libc::c_char,
-        LinkerSymbolsSize: u64,
+    /// Dispose the undefined references.
+    pub fn LLVMDisposeUndefinedReferencesEraVM(
+        References: *const *const ::libc::c_char,
+        ReferencesSize: u64,
     );
 
     /// Link EraVM module.
@@ -108,9 +111,12 @@ extern "C" {
     pub fn LLVMLinkEraVM(
         InMemBuf: LLVMMemoryBufferRef,
         OutMemBuf: *mut LLVMMemoryBufferRef,
-        LinkerSymbols: *const *const ::libc::c_char,
+        LinkerSymbolKeys: *const *const ::libc::c_char,
         LinkerSymbolValues: *const ::libc::c_char,
         LinkerSymbolsSize: u64,
+        FactoryDependencyKeys: *const *const ::libc::c_char,
+        FactoryDependencyValues: *const ::libc::c_char,
+        FactoryDependenciesSize: u64,
         ErrorMessage: *mut *mut ::libc::c_char,
     ) -> LLVMBool;
 }


### PR DESCRIPTION
# What ❔

Adds the support for linking factory dependencies for EraVM.

## Why ❔

Contracts with unlinked libraries are not ready for deployment, and they cannot have the bytecode hash either.
It means that we need to link EraVM in two iterations: libraries first, factory dependencies later.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
